### PR TITLE
Create index view page for contestants

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ I see that bachelorette's:
                   Hannah Brown
     Season 15 - The Most Dramatic Season Yet!
   )
+  #imagining season as being a separate class
 I also see a link to see that bachelorette's contestants
 When I click on that link
 I'm taken to "/bachelorettes/:bachelorette_id/contestants"

--- a/app/controllers/contestants_controller.rb
+++ b/app/controllers/contestants_controller.rb
@@ -1,0 +1,7 @@
+class ContestantsController < ApplicationController
+  def index
+    # @bachelorette = Bachelorette.find(params[:bachelorette_id])
+    # @contestants = @bachelorette.contestants
+    @contestants = Contestant.where(bachelorette_id: params[:bachelorette_id])
+  end
+end

--- a/app/views/bachelorettes/show.html.erb
+++ b/app/views/bachelorettes/show.html.erb
@@ -1,2 +1,4 @@
 <h1><%= @bachelorette.name %></h1>
 <p>Season <%= @bachelorette.season_number %> - <%= @bachelorette.description %></p>
+
+<%= link_to "Contestants", "#{@bachelorette.id}/contestants" %>

--- a/app/views/contestants/index.html.erb
+++ b/app/views/contestants/index.html.erb
@@ -1,0 +1,5 @@
+<h1>Contestants</h1>
+
+<% @contestants.each do |contestant| %>
+  <p><%= contestant.name %></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  get '/bachelorettes/:id', to: 'bachelorettes#show'
+  # get '/bachelorettes/:id', to: 'bachelorettes#show'
+  resources :bachelorettes, only: [:show] do
+    resources :contestants, only: [:index]
+  end
 end

--- a/spec/features/bachelorette_show_spec.rb
+++ b/spec/features/bachelorette_show_spec.rb
@@ -9,8 +9,25 @@ RSpec.describe "Bachelorette Show Page", type: :feature do
       visit "/bachelorettes/#{lena.id}"
 
       expect(page).to have_content("Lena")
-      
+
       expect(page).to have_content("Season #{lena.season_number} - Best season yet!")
+    end
+
+    it "I can see a contestants link" do
+      lena = Bachelorette.create(name: "Lena", season_number: 8, description: "Best season yet!")
+      tom = lena.contestants.create(name: "Tom")
+      bob = Contestant.create(name: 'Bob', bachelorette: lena)
+      jim = Contestant.create(name: 'Jim', bachelorette_id: lena.id)
+
+      visit "/bachelorettes/#{lena.id}"
+
+      expect(page).to have_link("Contestants")
+      click_on("Contestants")
+      expect(current_path).to eq("/bachelorettes/#{lena.id}/contestants")
+      save_and_open_page
+      expect(page).to have_content(tom.name)
+      expect(page).to have_content(bob.name)
+      expect(page).to have_content(jim.name)
     end
   end
 end


### PR DESCRIPTION
User story 1: Link to bachelorette's contestants

I first added a Contestants link in the bachelorette's show view, including the path
I updated my routes to make use of nested resources (contestants nested under bachelorettes), specifying which actions I would be defining for each (show for bachelorettes, index for contestants).
I followed that with creating a contestants controller to house the index action, which I defined as having access to all instances of contestants where the attribute of bachelorette_id is the bachelorette_id parameter.
Finally, I build the contestants index view where the name of each contestant belonging to a specific bachelorette can be seen.
